### PR TITLE
MacOS instruction: avoid entering interactive Python shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ $ mkvirtualenv sq -p python3
 
 ## MacOS
 ```
-1) Open Terminal and enter "python3" to install the interpreter and other command line tools
+1) Open Terminal and enter `python3 --version` to install the interpreter and other command line tools
 2) Once installed, proceed similarly to Linux installation:
    $ wget https://bootstrap.pypa.io/get-pip.py
    $ sudo python3 get-pip.py


### PR DESCRIPTION
I saw [this](https://twitter.com/MicrobiomDigest/status/1283088608157556737?s=20) tweet, and realized that the aim is to trigger MacOS to install XCode CLI tools etc, as a side effect of launching Python but if you don't realize you entered a Python shell, this can be tricky.

My suggestion involves:

- backticks to make it super hyper extra clear that one should not copy double quotes. It's orthogonal to the issue at hand, but I think it should help
- Using `python --version` should, in theory, do the same as launching Python itself, and will return immediately. I cannot test though.

Note: I'm not familiar with this software, so I don't claim this is correct. If you have any reason to believe this would not be a good change, you clearly know better :)