### PR TITLE
Performance improvements for copy-move detection

### DIFF
--- a/gui/cloning.py
+++ b/gui/cloning.py
@@ -231,13 +231,20 @@ class CloningWidget(ToolWidget):
                     bb = np.linalg.norm(b0 - b1)
                     ab = np.linalg.norm(a0 - b1)
                     ba = np.linalg.norm(b0 - a1)
-                    smallest = np.partition(np.array([aa, bb, ab, ba]), 1)[:2]
-                    if np.all(np.logical_and(smallest > 0, smallest < min_dist)):
-                        for g in group:
-                            if g.queryIdx == train1 and g.trainIdx == query1:
-                                break
-                        else:
-                            group.append(match1)
+
+                    if 0 < aa < min_dist and 0 < bb < min_dist:
+                        pass
+                    elif 0 < ab < min_dist and 0 < ba < min_dist:
+                        pass
+                    else:
+                        continue
+
+                    for g in group:
+                        if g.queryIdx == train1 and g.trainIdx == query1:
+                            break
+                    else:
+                        group.append(match1)
+
                 if len(group) >= cluster:
                     self.clusters.append(group)
                 progress.setValue(i)


### PR DESCRIPTION
I was looking through the code to understand what the individual parameters meant and saw a few things that looked like they could be tweaked for faster performance. I'm sure there are ways of doing the clustering in an even better way, but here's a quick attempt. On my sample image, the entire `if self.clusters is None` loop started at 84s and after this change takes 13s.

The first change I made was calculating all of the distances between matching keypoints. The previous loop structure meant that something like `len(matches)^2` distances were calculated out for the original matches.

I also pre-filtered down the list of matches to only the ones where the distance between the point was above min_dist instead of handling that in both the i and j loops.

The final change at https://github.com/GuidoBartoli/sherloq/compare/master...AlexRiina:master#diff-e06009cb5a3aa444ce736838cd58dd9cR237 prevents cases where a0 and a1 are really close and a0 and b1 are really close but a1 and b1 are not really close. I think goal of that loop is to pair a0 with either a1 or b1 and b0 with the other and the highlighted case is when b0 is not paired. 