### PR TITLE
Update requirements for python 3.11, add gitignore, and improve README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# macOS
+.DS_Store
+
+# virtualenv
+.venv/
+
+# byte-compiled/optimized/DLL files
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ While many commercial solutions have high retail prices and often reserved to la
 
 I strongly believe that *security-by-obscurity* is the wrong way to offer any kind of forensic service (i.e. "Using this proprietary software I guarantee you that this photo *is* pristine... and you have to trust me!"). Following the open-source philosophy, everyone should be able to try various techniques on their own, gain knowledge and share it to the community... even better if they contribute with code improvements! :)
 
-- [History](https://github.com/GuidoBartoli/sherloq#historry)
-- [Features](https://github.com/GuidoBartoli/sherloq#features)
-- [Screenshots](https://github.com/GuidoBartoli/sherloq#screenshots)
-- [Installation](https://github.com/GuidoBartoli/sherloq#installation)
-- [Updates](https://github.com/GuidoBartoli/sherloq#updates)
-- [Bibliography](https://github.com/GuidoBartoli/sherloq#bibliography)
+- [History](#history)
+- [Features](#features)
+- [Screenshots](#screenshots)
+- [Installation](#installation)
+- [Updates](#updates)
+- [Bibliography](#bibliography)
 
 # History
 The first version was written in 2015 using C++11 to build a command line utility with many options, but soon it turned to be too cumbersome and not much interactive. That version could be compiled with CMake after installing OpenCV, Boost and AlgLib libraries. This first proof of concept offered about 80% of planned features (see below for the full list).

--- a/gui/requirements.txt
+++ b/gui/requirements.txt
@@ -7,10 +7,10 @@ opencv-contrib-python-headless==4.6.0.66
 pandas==1.5.0
 pyside6==6.7.2
 python-magic==0.4.27
-rawpy==0.17.3
+rawpy==0.21.0
 scikit-learn==1.5.0
 sewar==0.4.5
-tensorflow==2.12.0
+tensorflow==2.16.1
 xgboost==1.6.2
 pillow==10.3.0
 PyWavelets==1.5.0


### PR DESCRIPTION
This PR:
* updates the dependencies rawpy and tensorflow to the minimum version that is compatible with Python 3.11.9
* git-ignores the invisible file generated on macs, the virtualenv folder, and compiled Python files
* makes the README table of contents links relative so they work in forks too