### PR TITLE
Add `pyproject.toml`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@
 
 # byte-compiled/optimized/DLL files
 __pycache__/
+
+# build outputs
+build
+dist
+Sherloq.egg-info

--- a/gui/sherloq.py
+++ b/gui/sherloq.py
@@ -467,7 +467,11 @@ class MainWindow(QMainWindow):
         self.statusBar().showMessage(message, 10000)
 
 
-if __name__ == "__main__":
+def main():
     application = QApplication(sys.argv)
     mainwindow = MainWindow()
     sys.exit(application.exec())
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "Sherloq"
+description = "An open-source digital image forensic toolset"
+version = "0.91"
+readme = "README.md"
+license = {file = "LICENSE"}
+requires-python = ">=3.11, <3.12" # 3.11.x
+dynamic = ["dependencies"]
+scripts = {sherloq = "gui.sherloq:main"}
+
+[tool.setuptools.dynamic]
+dependencies = {file = ["gui/requirements.txt"]}
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["*"]
+


### PR DESCRIPTION
Since [PEP-518](https://peps.python.org/pep-0518), `pyproject.toml` is the preferred way to specify build system requirements.

Having this file makes the project fit into the ecosystem better, and provides many benefits, such as making users able to build distributable binaries:

```shell
$ python -m build
[...]
Successfully built sherloq-0.91.tar.gz and Sherloq-0.91-py3-none-any.whl
$ ls dist 
Sherloq-0.91-py3-none-any.whl  sherloq-0.91.tar.gz
```

which can later be installed like this:

```shell
$ pip install dist/Sherloq-0.91-py3-none-any.whl
```

*learn more about the wheel format [here](https://packaging.python.org/en/latest/specifications/binary-distribution-format/)*

`pyproject.toml` can also specify lots of metadata, such as license, version of program, authors, maintainers, etc.