### PR TITLE
remove unused imports

### DIFF
--- a/gui/location.py
+++ b/gui/location.py
@@ -1,5 +1,3 @@
-import os
-
 from PySide6.QtCore import QUrl, QTemporaryDir, Qt
 from PySide6.QtWebEngineWidgets import QWebEngineView
 from PySide6.QtWidgets import QVBoxLayout, QLabel

--- a/gui/median.py
+++ b/gui/median.py
@@ -13,7 +13,6 @@ from PySide6.QtWidgets import (
     QProgressDialog,
     QCheckBox,
 )
-from joblib import load
 
 from tools import ToolWidget
 from utility import modify_font, pad_image

--- a/gui/quality.py
+++ b/gui/quality.py
@@ -18,7 +18,7 @@ from PySide6.QtWidgets import (
 from matplotlib.backends.backend_qt5agg import FigureCanvas
 from matplotlib.figure import Figure
 
-from jpeg import TABLE_SIZE, ZIG_ZAG, DCT_SIZE, get_tables, loss_curve, compress_jpg
+from jpeg import TABLE_SIZE, ZIG_ZAG, DCT_SIZE, get_tables, loss_curve
 from tools import ToolWidget
 from utility import modify_font, exiftool_exe, clip_value
 

--- a/gui/resampling.py
+++ b/gui/resampling.py
@@ -7,24 +7,19 @@ from PySide6.QtWidgets import (
     QDoubleSpinBox,
     QVBoxLayout,
     QSlider,
-    QHBoxLayout,
     QLabel,
-    QSpinBox,
     QCheckBox,
     QPushButton,
     QGridLayout,
     QSizePolicy,
     QScrollArea,
 )
-from PySide6.QtGui import QTransform
 from PySide6.QtCore import Qt
 from tools import ToolWidget
-from viewer import ImageViewer
 
 # resampling nessecary imports
 import numpy as np
 import cv2
-import random
 import matplotlib.pyplot as plt
 
 plt.rcParams["savefig.dpi"] = 200  # increase deafault save resolution

--- a/gui/splicing.py
+++ b/gui/splicing.py
@@ -13,7 +13,7 @@ from noiseprint.noiseprint import genNoiseprint
 from noiseprint.noiseprint_blind import genMappUint8
 from noiseprint.noiseprint_blind import noiseprint_blind_post
 from tools import ToolWidget
-from utility import modify_font, norm_mat, gray_to_bgr
+from utility import modify_font, norm_mat
 from viewer import ImageViewer
 
 


### PR DESCRIPTION
while fixing some typos, my lsp showed me some imports that were unused

There were some more that are currently unused but are referenced in code that is commented out. I only removed unused imports that weren't referenced anywhere in the file.