### PR TITLE
Fix: TruFor manipulation probability displaying values > 100%

### DIFF
--- a/gui/trufor.py
+++ b/gui/trufor.py
@@ -113,7 +113,7 @@ class TruForWidget(ToolWidget):
                     prob_score = 0
                     print(f"Error det_score: {e}")
 
-                self.output_label.setText(self.tr("Manipulation probability according to TruFor: " + str(prob_score*100) + ' %'))
+                self.output_label.setText(self.tr("Manipulation probability according to TruFor: " + str(prob_score) + ' %'))
                 # Save prediction temporarily and convert to BGR format for sherloq viewer
                 temp_filename = "temp_mask.png"
                 plt.imsave(temp_filename, prediction, cmap='RdBu_r', vmin=0, vmax=1)


### PR DESCRIPTION
## Description
This PR fixes a minor but very noticeable logic bug in the TruFor plugin interface where the "Manipulation probability" displays absurdly high percentages (often > 1000%). 

The issue was caused by a redundant multiplication. The variable `prob_score` is already converted to a percentage (`det_score * 100`) earlier in the `process_image` block, but it was being multiplied by 100 again during the UI label update.

## Steps to Reproduce
Processing the original Lena Forsén test image results in a manipulation probability exceeding 1000%.
<img width="1200" height="572" alt="Lenna_(test_image)_trufor" src="https://github.com/user-attachments/assets/4ab64ec6-2413-48c8-a36c-2c2b710d8c6a" />